### PR TITLE
Add integrity and crossorigin to normalize.css link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
   {%- endif -%}
   <link rel="image_src" href="{% if page.featured_image %}{{ page.featured_image | relative_url }}{% else %}{{ site.primary_logo | relative_url }}{% endif %}">
   <link rel="shortcut icon" href="{{ site.favicon | relative_url }}">
-  <link rel="stylesheet" type="text/css" href="https://necolas.github.io/normalize.css/4.1.1/normalize.css">
+  <link rel="stylesheet" href="https://necolas.github.io/normalize.css/4.1.1/normalize.css" integrity="sha384-fVquC3DHMyHQJ7MasHkVMX2RLx5O6r2+Eh/NB9eZUSRGntVASwPIr1DFKzSpwTxD" crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="{{ "/assets/css/style.css" | relative_url }}">
   <link rel="stylesheet" type="text/css" href="{{ "/assets/css/style2.css" | relative_url }}">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i" rel="stylesheet">


### PR DESCRIPTION
Updated the stylesheet link for normalize.css to include integrity and crossorigin attributes.